### PR TITLE
Add option lang for running Arabic sushi chef

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # sushi-chef-phet
+```
+pip3 install -r requirements.txt
+python3 chef.py --token=<your_token> lang=<lang_code>
+```
+
+For example, to run PhET English sushi chef, use command`python3 chef.py --token=<your_token>`.
+
+To run PhET Arabic sushi chef, use command `python3 chef.py --token=<your_token> lang=ar`


### PR DESCRIPTION
Add the option `lang` when running sushi chef so that we can use the command `python3 chef.py --token=<your_token> lang=ar` to run the Arabic sushi chef.

Running the English sushi chef can still use the old command.

Add `by-level` to `ID_BLACKLIST`, since Arabic channel only wants the topic folders that are subjects. `by-level` is not a subject. Please let me know if English channel needs the `by-level` topic node.

One major change is that we start to use localized item's id to represent the content id, instead of using the same id for the same piece of content across multiple languages.